### PR TITLE
Able to use ShapeManager for Indexes without ShapeParser

### DIFF
--- a/ShapeFilesParser.Business/Models/GeometryType.cs
+++ b/ShapeFilesParser.Business/Models/GeometryType.cs
@@ -20,6 +20,6 @@ namespace ShapeFilesParser.Business.Models
         PolyLineM = 23,
         PolygonM = 25,
         MultiPointM = 28,
-        MultiPatch = 31,
+        MultiPath = 31,
     }
 }

--- a/ShapeFilesParser.Business/Models/ShapeIndex.cs
+++ b/ShapeFilesParser.Business/Models/ShapeIndex.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShapeFilesParser.Business.Models
+{
+    public class ShapeIndex
+    {
+        public int ContentLength { get; internal set; }
+        public int Offset { get; internal set; }
+        public Dictionary<string,string> Metadatas { get; set; }
+    }
+}

--- a/ShapeFilesParser.Business/Models/ShapeIndexList.cs
+++ b/ShapeFilesParser.Business/Models/ShapeIndexList.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShapeFilesParser.Business.Models
+{
+    public class ShapeIndexList : List<ShapeIndex>
+    {
+        public int FileCode { get; set; }
+        public int FileLength { get; set; }
+        public int Version { get; set; }
+        public GeometryType GlobalShapeType { get; set; }
+        public double XMin { get; set; }
+        public double YMin { get; set; }
+        public double XMax { get; set; }
+        public double YMax { get; set; }
+        public double ZMin { get; set; }
+        public double ZMax { get; set; }
+        public double MMin { get; set; }
+        public double MMax { get; set; }
+    }
+}

--- a/ShapeFilesParser.Business/ShapeFilesParser.Business.csproj
+++ b/ShapeFilesParser.Business/ShapeFilesParser.Business.csproj
@@ -49,6 +49,8 @@
     <Compile Include="Models\Point.cs" />
     <Compile Include="Models\PointZ.cs" />
     <Compile Include="Models\PolygonZ.cs" />
+    <Compile Include="Models\ShapeIndex.cs" />
+    <Compile Include="Models\ShapeIndexList.cs" />
     <Compile Include="Parsers\BaseShapeParser.cs" />
     <Compile Include="Parsers\PointParser.cs" />
     <Compile Include="Parsers\PointZParser.cs" />

--- a/ShapeFilesParser.ConsoleTest/Program.cs
+++ b/ShapeFilesParser.ConsoleTest/Program.cs
@@ -13,8 +13,8 @@ namespace ShapeFilesParser.ConsoleTest
         static void Main(string[] args)
         {
             string sourcename = @"RESEAU_ROUTIER\AERODROME";//your shape file base name
-            ShapeManager<PointZ> shapeManager = new ShapeManager<PointZ>(new Business.Parsers.PointZParser(), 11);
-            var shapes = shapeManager.ParseShapeFiles(sourcename);
+            ShapeManager shapeManager = new ShapeManager();
+            var shapes = shapeManager.GetShapes(sourcename, new Business.Parsers.PointZParser());
         }
     }
 }

--- a/ShapeFilesParser.Tests/ParserTests.cs
+++ b/ShapeFilesParser.Tests/ParserTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ShapeFilesParser.Business;
+using ShapeFilesParser.Business.Parsers;
+
+namespace ShapeFilesParser.Tests
+{
+    [TestClass]
+    public class ParserTests
+    {
+        private string _basePath; 
+
+        public ParserTests()
+        {
+#warning use your own files an base folder to test
+            _basePath = @"BaseFolder\";//your shape file base name
+        }
+
+        [TestMethod]
+        public void ParsePointZ()
+        {
+            string fullpath = _basePath + @"RESEAU_ROUTIER\AERODROME";
+
+            PointZParser parser = new PointZParser();
+            ShapeManager shapeManager = new ShapeManager();
+            var index = shapeManager.GetInfos(fullpath);
+
+            Assert.IsTrue(index.GlobalShapeType == Business.Models.GeometryType.PointZ);
+
+            var shapesPointZ = shapeManager.GetShapes(fullpath, parser);
+            var shape = shapeManager.GetShape(fullpath, parser, index[0]);
+        }
+
+        [TestMethod]
+        public void ParsePolygonZ()
+        {
+            string fullpath = _basePath + @"ADMINISTRATIF\COMMUNE";
+
+            PolygonZParser parser = new PolygonZParser();
+            ShapeManager shapeManager = new ShapeManager();
+            var index = shapeManager.GetInfos(fullpath);
+
+            Assert.IsTrue(index.GlobalShapeType == Business.Models.GeometryType.PolygonZ);
+
+            var shapesPointZ = shapeManager.GetShapes(fullpath, parser);
+            var shape = shapeManager.GetShape(fullpath, parser, index[0]);
+        }
+    }
+}

--- a/ShapeFilesParser.Tests/Properties/AssemblyInfo.cs
+++ b/ShapeFilesParser.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ShapeFilesParser.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ShapeFilesParser.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8cdf1ff4-6ddf-49c0-9864-16979e4becb7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ShapeFilesParser.Tests/ShapeFilesParser.Tests.csproj
+++ b/ShapeFilesParser.Tests/ShapeFilesParser.Tests.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8CDF1FF4-6DDF-49C0-9864-16979E4BECB7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ShapeFilesParser.Tests</RootNamespace>
+    <AssemblyName>ShapeFilesParser.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="ParserTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ShapeFilesParser.Business\ShapeFilesParser.Business.csproj">
+      <Project>{b01eb8e5-9c4b-4886-b8c5-17fb33b570ab}</Project>
+      <Name>ShapeFilesParser.Business</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ShapeFilesParser.sln
+++ b/ShapeFilesParser.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShapeFilesParser.Business",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShapeFilesParser.ConsoleTest", "ShapeFilesParser.ConsoleTest\ShapeFilesParser.ConsoleTest.csproj", "{78869D54-4388-4DC7-AAD7-CA79708A6D9A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShapeFilesParser.Tests", "ShapeFilesParser.Tests\ShapeFilesParser.Tests.csproj", "{8CDF1FF4-6DDF-49C0-9864-16979E4BECB7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{78869D54-4388-4DC7-AAD7-CA79708A6D9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{78869D54-4388-4DC7-AAD7-CA79708A6D9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{78869D54-4388-4DC7-AAD7-CA79708A6D9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8CDF1FF4-6DDF-49C0-9864-16979E4BECB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8CDF1FF4-6DDF-49C0-9864-16979E4BECB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CDF1FF4-6DDF-49C0-9864-16979E4BECB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CDF1FF4-6DDF-49C0-9864-16979E4BECB7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
ShapeManager is not generic anymore. It can read indexes without ShapeParser. ShapeParser is used only when calling GetShape(s) methods